### PR TITLE
shows events without a category

### DIFF
--- a/client/src/Pages/MyStatement/MyStatement.js
+++ b/client/src/Pages/MyStatement/MyStatement.js
@@ -76,7 +76,7 @@ const MyStatement = () => {
           ||(event.category=="family" && filters.categoryFilter[4])
           ||(event.category=="recreation" && filters.categoryFilter[5])
           ||(event.category=="income" && filters.categoryFilter[6])
-          ||(event.category=="other" && filters.categoryFilter[7])
+          ||((event.category=="other" || event.category == "") && filters.categoryFilter[7])
           ) {
             if (filters.yearFilter === "all years"){
               //check if "all years" is on


### PR DESCRIPTION
I noticed that when you didn't select a category when creating an event, it would not show up the statements page at all. 

Added a conditional so that it displays when 'other' is selected